### PR TITLE
[Feat] Quit 구현과 자잘한 경로수정 #54

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -14,7 +14,9 @@ const std::map<std::string, Channel> Server::getChannels() { return (_channels);
 const Channel Server::findChannel(Client client, std::string name) {
 	std::map<std::string, Channel>::iterator it = _channels.find(name);
 
-	if (it != _channels.end()) return (it->second);
+	if (it != _channels.end()){
+				return (it->second);
+}
 
 	std::vector<int> fd;
 	fd.push_back(client.getFd());

--- a/Server.cpp
+++ b/Server.cpp
@@ -28,7 +28,7 @@ const Client Server::findClient(Client client, std::string name) {
 	std::map<std::string, Client>::iterator it = _clients.find(name);
 
 	if (it != _clients.end()) return (it->second);
-	if (!client) throw Message();
+	// if (!client) throw Message();
 
 	std::vector<int> fd;
 	fd.push_back(client.getFd());

--- a/commands/Command.cpp
+++ b/commands/Command.cpp
@@ -4,4 +4,4 @@ Command::Command(Client client, std::string type): _client(client), _type(type) 
 
 Command::~Command() {}
 
-Message Command::excute() { return Message(); }
+Message Command::execute() { return Message(); }

--- a/commands/Command.hpp
+++ b/commands/Command.hpp
@@ -15,7 +15,7 @@ class Command {
 	public:
 		Command(Client client, std::string type);
 		virtual ~Command();
-		virtual Message excute() = 0;
+		virtual Message execute() = 0;
 };
 
 #endif

--- a/commands/PrivMsg.hpp
+++ b/commands/PrivMsg.hpp
@@ -2,7 +2,7 @@
 # define PRIVMSG_HPP
 
 # include "Command.hpp"
-# include "Server.hpp"
+# include "../Server.hpp"
 
 class PrivMsg : public Command
 {

--- a/commands/Quit.cpp
+++ b/commands/Quit.cpp
@@ -1,0 +1,12 @@
+# include "Quit.hpp"
+
+Quit::Quit(Client client, std::string channel) : Command(client, "QUIT"), _channel(channel){
+}
+
+Quit::~Quit(){
+}
+
+Message Quit::execute(){
+	Server::removeClient(_client);
+	return Message();
+}

--- a/commands/Quit.hpp
+++ b/commands/Quit.hpp
@@ -1,0 +1,18 @@
+#ifndef QUIT_HPP
+# define QUIT_HPP
+
+# include "../Server.hpp"
+# include "Command.hpp"
+
+class Quit : public Command {
+	private:
+		std::string _channel;
+
+	public:
+		Quit(Client client, std::string channel);
+		~Quit();
+
+		Message execute();
+};
+
+#endif

--- a/testCommand.cpp
+++ b/testCommand.cpp
@@ -1,22 +1,27 @@
 #include "srcs/utils.hpp"
-// #include "Server.hpp"
-// #include "commands/Join.hpp"
-#include "commands/PrivMsg.hpp"
+#include "Server.hpp"
+#include "Channel.hpp"
+#include "Client.hpp"
+#include "commands/Command.hpp"
+#include "commands/Quit.hpp"
+// #include “commands/PrivMsg.hpp”
 #include <iostream>
 
 int main()
 {
-//		Server(int port, std::string password, std::string adminName, std::string adminPassword);
-	Server server(6667, "password", "admin", "admin");
-	User user("name", "nickName");
-	Channel channel("#name", user);
-	Server::addChannel(channel);
-	Server::addUser(user);
+//      Server(int port, std::string password, std::string adminName, std::string adminPassword);
+    Server server(6667, "password", "admin", "admin");
+	Client client( 0, "name", "nickName");
+    Channel channel("#Quit", client);
+    Server::addChannel(channel);
+    Server::addClient(client);
 
-	// Join join("new", user);
-	// Message message = join.excute();
-	PrivMsg privMsg(user, "#name", "hello");
-	Message message = privMsg.execute();
-	std::cout << message.getMessage() << std::endl;
-	return (0);
+    Quit quit(client, channel.getName());
+    std::cout << quit.execute().getMessage() << std::endl;
+    // Join join(“new”, user);
+    // Message mssag = jin.excut();
+    // PrivMsg privMg(usr, "#name", “hello”);
+    // Message message = privMsg.execute();
+    // std::cout << message.getMessage() << std::endl;
+    return (0);
 }


### PR DESCRIPTION
## 개요
[Feat] Quit 구현과 자잘한 경로수정 #54

## 작업사항
피그마의 /exit -> /quit 으로 수정 rfc1459명세
헤더 경로 변경과
Command.hpp && Command.cpp excute()->execute() 로 변경

테스트 시 exit 작동이 잘되었습니다  테스트파일을 참고해 주세요!