### PR TITLE
[Feat] 클라이언트 소켓 세부 설정 #47

### DIFF
--- a/srcs/socket.cpp
+++ b/srcs/socket.cpp
@@ -50,7 +50,7 @@ int main()
 	while (true)
 	{
 		struct kevent occured_event[2];
-		int occured_event_cnt = kevent(kq, &register_event[0], registered_event.size(), occured_event, 2, NULL);
+		int occured_event_cnt = kevent(kq, &register_event[0], register_event.size(), occured_event, 2, NULL);
 		if (occured_event_cnt == -1)
 			err_exit("calling kevent : " + std::string(strerror(errno)));
 
@@ -61,7 +61,7 @@ int main()
 			// 이벤트가 발생한 식별자가 서버 소켓의 fd인 경우
 			if (occured_event[i].ident == server_socket)
 			{
-				std::cout << "TYPE " << registered_event[i].filter << " event occurs in server_socket!" << std::endl;
+				std::cout << "TYPE " << register_event[i].filter << " event occurs in server_socket!" << std::endl;
 
 				int client_socket = accept(server_socket, NULL, NULL);
 				if (client_socket == -1)

--- a/srcs/socket.cpp
+++ b/srcs/socket.cpp
@@ -7,14 +7,12 @@
 #include <sys/event.h>
 #include <vector>
 
-void err_exit(std::string error_msg)
-{
+void err_exit(std::string error_msg) {
 	std::cerr << "Error " << error_msg << std::endl;
 	exit(1);
 }
 
-int main()
-{
+int main() {
 	int server_socket;
 	struct sockaddr_in server_addr;
 
@@ -46,8 +44,7 @@ int main()
 
 	std::cout << "Waiting for incoming connections..." << std::endl;
 
-	while (true)
-	{
+	while (true) {
 		struct kevent client_socket_event[2];
 		struct kevent occured_events[100];
 		int occured_events_cnt = kevent(kq, NULL, 0, occured_events, 100, NULL);
@@ -56,19 +53,16 @@ int main()
 
 		std::cout << occured_events_cnt << " events occur!" << std::endl;
 
-		for (int i = 0; i < occured_events_cnt; ++i)
-		{
+		for (int i = 0; i < occured_events_cnt; ++i) {
 			// 이벤트가 발생한 식별자가 서버 소켓의 fd인 경우
-			if (occured_events[i].ident == server_socket)
-			{
+			if (occured_events[i].ident == server_socket) {
 				std::cout << "READ event occurs in server_socket!" << std::endl;
 
 				int client_socket = accept(server_socket, NULL, NULL);
 				if (client_socket == -1)
 					err_exit("accepting client : " + std::string(strerror(errno)));
 
-				std::cout << client_socket << ": New client connect\n"
-						  << std::endl;
+				std::cout << client_socket << ": New client connect\n" << std::endl;
 
 				if (fcntl(client_socket, F_SETFL, O_NONBLOCK) == -1)
 					err_exit("setting client socket flag : " + std::string(strerror(errno)));
@@ -78,8 +72,7 @@ int main()
 				kevent(kq, &client_socket_event[0], 2, NULL, 0, NULL);
 			}
 			// 이벤트가 발생한 식별자가 클라이언트 소켓의 fd인 경우
-			else
-			{
+			else {
 			}
 		}
 	}

--- a/srcs/socket.cpp
+++ b/srcs/socket.cpp
@@ -49,7 +49,7 @@ int main()
 		err_exit("creating kqueue : " + std::string(strerror(errno)));
 
 	std::vector<struct kevent> register_events;
-	initialize_new_event(register_event, server_socket, EVFILT_READ, EV_ADD);
+	initialize_new_event(register_events, server_socket, EVFILT_READ, EV_ADD);
 
 	std::cout << "Waiting for incoming connections..." << std::endl;
 
@@ -67,7 +67,7 @@ int main()
 			// 이벤트가 발생한 식별자가 서버 소켓의 fd인 경우
 			if (occured_events[i].ident == server_socket)
 			{
-				std::cout << "TYPE " << register_event[i].filter << " event occurs in server_socket!" << std::endl;
+				std::cout << "TYPE " << register_events[i].filter << " event occurs in server_socket!" << std::endl;
 
 				int client_socket = accept(server_socket, NULL, NULL);
 				if (client_socket == -1)
@@ -77,6 +77,9 @@ int main()
 
 				if (fcntl(client_socket, F_SETFL, O_NONBLOCK) == -1)
 					err_exit("setting client socket flag : " + std::string(strerror(errno)));
+
+				initialize_new_event(register_events, client_socket, EVFILT_READ, EV_ADD);
+				initialize_new_event(register_events, client_socket, EVFILT_WRITE, EV_ADD);
 			}
 			else
 			{

--- a/srcs/socket.cpp
+++ b/srcs/socket.cpp
@@ -22,7 +22,7 @@ int main()
 	if (server_socket == -1)
 		err_exit("creating socket : " + std::string(strerror(errno)));
 
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_addr.s_addr = htons(INADDR_ANY);
 	server_addr.sin_port = htons(8080);

--- a/srcs/socket.cpp
+++ b/srcs/socket.cpp
@@ -20,7 +20,7 @@ int main()
 
 	server_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (server_socket == -1)
-		err_exit("creating socket : " + std::string(strerror(errno)));
+		err_exit("creating server socket : " + std::string(strerror(errno)));
 
 	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
@@ -28,13 +28,13 @@ int main()
 	server_addr.sin_port = htons(8080);
 
 	if (bind(server_socket, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
-		err_exit("binding socket : " + std::string(strerror(errno)));
+		err_exit("binding server socket : " + std::string(strerror(errno)));
 
 	if (listen(server_socket, 5) == -1)
-		err_exit("socket listening : " + std::string(strerror(errno)));
+		err_exit("server socket listening : " + std::string(strerror(errno)));
 
 	if (fcntl(server_socket, F_SETFL, O_NONBLOCK) == -1)
-		err_exit("setting socket flag : " + std::string(strerror(errno)));
+		err_exit("setting server socket flag : " + std::string(strerror(errno)));
 
 	int kq = kqueue();
 	if (kq == -1)
@@ -68,6 +68,9 @@ int main()
 					err_exit("accepting client : " + std::string(strerror(errno)));
 
 				std::cout << client_socket << ": New client connected" << std::endl;
+
+				if (fcntl(client_socket, F_SETFL, O_NONBLOCK) == -1)
+					err_exit("setting client socket flag : " + std::string(strerror(errno)));
 			}
 			else
 			{


### PR DESCRIPTION
## 개요
생성된 클라이언트 소켓의 특성을 설정하고, 클라이언트 소켓에서 발생할 이벤트를 위한 kevent 구조체를 등록

## 작업사항
- 클라이언트 소켓 `NON-BLOCK`으로 설정
- 클라이언트 이벤트 모니터링을 위한 `kevent` 구조체 생성 및 초기화
- `test` : 커널에 이벤트를 등록할때, 한 개씩 등록 가능한지, 커널에 등록된 이벤트를 한 배열로 모두 갖고 있어야 하는지
  - 한 개씩 등록 가능.
  - 해당 이벤트 구조체를 계속 갖고 있지 않아도 커널에 한번 등록되면 서버 내의 `kevent` 구조체와는 별도로 유지 관리됨.
- `kevent()` 함수 사용 분리
  - 커널에 이벤트 등록할 때
  - 커널에서 발생한 이벤트 받아올 때
- 자동 포매팅 off

## 변경로직
- `kevent()` 함수 이벤트 등록/받아오기로 기능 분리해서 사용
- 이벤트 등록 이후 `kevent` 구조체 보관하지 않음
- 따라서 vector 대신 이벤트 등록을 위한 크기가 정해진 배열 사용 (`read`/`write` 2개)