### PR TITLE
[Feat] 유저 호스트 주소 받아오는 함수 구현 #24

### DIFF
--- a/srcs/client_socket.cpp
+++ b/srcs/client_socket.cpp
@@ -1,19 +1,23 @@
 #include "client_socket.hpp"
+#include "netdb.h"
 
 void create_client_socket(int server_socket, int kq) {
 	struct sockaddr_in client_addr;
-	int new_client_socket = accept(server_socket, (struct sockaddr *)&client_addr, NULL);
+	socklen_t client_addr_size = sizeof(client_addr);
+	int new_client_socket = accept(server_socket, (struct sockaddr *)&client_addr, &client_addr_size);
 	if (new_client_socket == -1)
 		err_exit("accepting client : " + std::string(strerror(errno)));
 
+	char client_host[NI_MAXHOST];
+	getnameinfo((struct sockaddr*)&client_addr, client_addr_size, client_host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+	
+	std::cout << client_host << std::endl;
 	std::cout << new_client_socket << ": New client connected\n" << std::endl;
 
 	if (fcntl(new_client_socket, F_SETFL, O_NONBLOCK) == -1)
 		err_exit("setting client socket flag : " + std::string(strerror(errno)));
 
 	Client client;
-
-	std::cout << client_addr.sin_addr.s_addr << std::endl;
 
 	struct kevent client_socket_event[2];
 	EV_SET(&client_socket_event[0], new_client_socket, EVFILT_READ, EV_ADD, 0, 0, NULL);


### PR DESCRIPTION
## 개요
유저 호스트 주소 받아오는 함수 구현

## 작업사항
- client socket 생성 시 주소 저장할 수 있는 구조체 `sockaddr_in`을 함께 넣어줌
- `getnameinfo` 함수로 호스트 주소 로드
- 로드한 호스트 주소 Client의 hostname에 저장
- Server에 새로 생성된 Client 저장

## 변경로직