### PR TITLE
[Fix] Command 명세에 맞게 쉼표로 구분된 다중 메시지 리턴 #22

### DIFF
--- a/commands/Join.cpp
+++ b/commands/Join.cpp
@@ -4,12 +4,12 @@ Join::Join(Client client, std::string channel) : Command(client, "JOIN"), _chann
 
 Join::~Join() {}
 
-void Join::checkValidName() {
-	if ((_channel[0] != '#' && _channel[0] != '&') || _channel.size() > 200){
+void Join::checkValidName(std::string& name) {
+	if ((name[0] != '#' && name[0] != '&') || name.size() > 200){
 		std::vector<int> targetFd;
 		targetFd.push_back(_client.getFd());
 		std::vector<Message> messages;
-		messages.push_back(Message(targetFd, ERR_NOSUCHCHANNEL, _channel));
+		messages.push_back(Message(targetFd, ERR_NOSUCHCHANNEL, name));
 		throw (messages);
 	}
 }
@@ -27,20 +27,32 @@ void Join::checkChannelNum() {
 	prefix JOIN :channel
 */
 std::vector<Message> Join::execute(){
-	Channel channel;
-	try{
-		channel = Server::findChannel(_client, _channel);
-	}
-	catch (std::vector<Message> &e){
-		checkValidName();
-		checkChannelNum();
-		std::vector<int> targetFd;
-		targetFd.push_back(_client.getFd());
-		channel = Channel(_channel, _client);
-		Server::addChannel(channel);
-	}
-	Server::addClientToChannel(_client, channel);
+	std::vector<std::string> targetList = ft::split(_channel, ',');
+	std::vector<std::string>::iterator it = targetList.begin();
+	std::vector<std::string>::iterator ite = targetList.end();
 	std::vector<Message> messages;
-	messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + _channel));
+	Channel channel;
+
+	for (; it != ite; it++) {
+		try{
+			channel = Server::findChannel(_client, *it);
+			Server::addClientToChannel(_client, channel);
+			messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + *it));
+		}
+		catch (std::vector<Message> &e){
+			std::vector<int> targetFd;
+			try {
+				checkValidName(*it);
+				checkChannelNum();
+				targetFd.push_back(_client.getFd());
+				channel = Channel(*it, _client);
+				Server::addChannel(channel);
+				Server::addClientToChannel(_client, channel);
+				messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + *it));
+			} catch (std::vector<Message> &e) {
+				messages.push_back(e[0]);
+			}
+		}
+	}
 	return messages;
 }

--- a/commands/Join.cpp
+++ b/commands/Join.cpp
@@ -9,7 +9,7 @@ void Join::checkValidName(std::string& name) {
 		std::vector<int> targetFd;
 		std::vector<Message> messages;
 		messages.push_back(Message(targetFd, ERR_NOSUCHCHANNEL, name));
-		throw (messages);
+		throw messages;
 	}
 }
 

--- a/commands/Join.hpp
+++ b/commands/Join.hpp
@@ -9,7 +9,7 @@ class Join : public Command {
 		std::string _channel;
 		std::string _target;
 		void checkChannelNum();
-		void checkValidName();
+		void checkValidName(std::string& name);
 
 	public:
 		Join(Client client, std::string channel);

--- a/commands/Part.cpp
+++ b/commands/Part.cpp
@@ -5,11 +5,25 @@ Part::Part(Client client, std::string channel) : Command(client, "PART"), _chann
 Part::~Part() {}
 
 std::vector<Message> Part::execute(){
-	Channel channel;
-	channel = Server::findChannel( _client, _channel);
-	channel.findClient(_client, _client.getNickName());
-	Server::removeClientFromChannel(_client, channel);
+	std::vector<std::string> targetList = ft::split(_channel, ',');
+	std::vector<std::string>::iterator it = targetList.begin();
+	std::vector<std::string>::iterator ite = targetList.end();
 	std::vector<Message> messages;
-	messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + _channel));
+
+	for (; it != ite; it++) {
+		try{
+			Channel channel;
+			channel = Server::findChannel( _client, *it);
+			channel.findClient(_client, _client.getNickName());
+			Server::removeClientFromChannel(_client, channel);
+			messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + *it));
+		}
+		catch (std::vector<Message> &e){
+			std::vector<int> targetFd;
+			std::vector<Message> messages;
+			targetFd.push_back(_client.getFd());
+			messages.push_back(Message(targetFd, ERR_NOSUCHCHANNEL, *it));
+		}
+	}
 	return messages;
 }

--- a/commands/PrivMsg.cpp
+++ b/commands/PrivMsg.cpp
@@ -15,19 +15,24 @@ const std::string PrivMsg::getMsg() const { return (_target + " :" + _msg); }
 std::vector<Message> format
 - :<clientNick>!<clientName>@<clientHost> PRIVMSG <target> :<msg>
 */
-std::vector<Message>	PrivMsg::execute()
+std::vector<Message> PrivMsg::execute()
 {
 	std::vector<int> targetFd;
 	std::vector<Message> messages;
-	if (_target[0] == '#')
-	{
-		Channel target = Server::findChannel(_client, _target);
-		targetFd = target.getFds();
-		messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
-		return (messages);
+	std::vector<std::string> targetList = ft::split(_target, ',');
+	std::vector<std::string>::iterator it = targetList.begin();
+	std::vector<std::string>::iterator ite = targetList.end();
+
+	for (; it != ite; it++) {
+		if ((*it)[0] == '#') {
+			Channel target = Server::findChannel(_client, *it);
+			targetFd = target.getFds();
+			messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
+		} else {
+			Client target = Server::findClient(_client, *it);
+			targetFd.push_back(target.getFd());
+			messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
+		}
 	}
-	Client target = Server::findClient(_client, _target);
-	targetFd.push_back(target.getFd());
-	messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
 	return (messages);
 }

--- a/commands/PrivMsg.cpp
+++ b/commands/PrivMsg.cpp
@@ -15,8 +15,7 @@ const std::string PrivMsg::getMsg() const { return (_target + " :" + _msg); }
 std::vector<Message> format
 - :<clientNick>!<clientName>@<clientHost> PRIVMSG <target> :<msg>
 */
-std::vector<Message> PrivMsg::execute()
-{
+std::vector<Message> PrivMsg::execute() {
 	std::vector<int> targetFd;
 	std::vector<Message> messages;
 	std::vector<std::string> targetList = ft::split(_target, ',');

--- a/commands/PrivMsg.cpp
+++ b/commands/PrivMsg.cpp
@@ -34,5 +34,5 @@ std::vector<Message> PrivMsg::execute()
 			messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
 		}
 	}
-	return (messages);
+	return messages;
 }


### PR DESCRIPTION
## 개요
Command 명세에 맞게 쉼표로 구분된 다중 메시지 리턴
## 작업사항
- PRIVMSG 여러 대상에게 보낼 수 있도록 수정
- JOIN도
- PART도
