### PR TITLE
[Feat] read 이벤트만으로 핸들링하는 로직

### DIFF
--- a/srcs/client_socket.cpp
+++ b/srcs/client_socket.cpp
@@ -1,5 +1,4 @@
 #include "client_socket.hpp"
-#include "netdb.h"
 
 void create_client_socket(int server_socket, int kq) {
 	struct sockaddr_in client_addr;
@@ -11,16 +10,21 @@ void create_client_socket(int server_socket, int kq) {
 	char client_host[NI_MAXHOST];
 	getnameinfo((struct sockaddr*)&client_addr, client_addr_size, client_host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 	
-	std::cout << client_host << std::endl;
-	std::cout << new_client_socket << ": New client connected\n" << std::endl;
+	std::cout << client_host << ": New client connected\n" << std::endl;
 
 	if (fcntl(new_client_socket, F_SETFL, O_NONBLOCK) == -1)
 		err_exit("setting client socket flag : " + std::string(strerror(errno)));
 
 	Client client;
+	client.setHostName(client_host);
+	Server::addClient(client);
 
 	struct kevent client_socket_event[2];
 	EV_SET(&client_socket_event[0], new_client_socket, EVFILT_READ, EV_ADD, 0, 0, NULL);
-	EV_SET(&client_socket_event[1], new_client_socket, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
+	EV_SET(&client_socket_event[1], new_client_socket, EVFILT_WRITE, EV_ONESHOT, 0, 0, NULL);
 	kevent(kq, &client_socket_event[0], 2, NULL, 0, NULL);
+
+	// 임시 접속 메시지
+	char message[] = "🍀 WELCOME TO IRC SERVER 🍀\n";
+	send(new_client_socket, message, sizeof(message), 0);
 }

--- a/srcs/client_socket.hpp
+++ b/srcs/client_socket.hpp
@@ -1,8 +1,10 @@
 #ifndef CLIENT_SOCKET_HPP
 #define CLIENT_SOCKET_HPP
 
+#include "netdb.h"
 #include "server_socket.hpp"
 #include "../Client.hpp"
+#include "../Server.hpp"
 
 void create_client_socket(int server_socket, int kq);
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -53,12 +53,14 @@ int main(int argc, char *argv[]) {
 				// WRITE 이벤트 발생
 				} else if (occurred_events[i].filter == EVFILT_WRITE) {
 					// 해당 클라이언트에 보낼 메시지가 있는 경우만 전송하게 조건 추가
-					char message[] = "";
-					ssize_t n = send(event_client_socket, message, sizeof(message), 0);
-					if (n < 0) {
-						err_exit("sending to client socket : " + std::string(strerror(errno)));
-					} else {
-						// 메시지 전송 성공 -> 해당 클라이언트에 보낼 메시지 삭제 해주기
+					if (false) {
+						char message[] = "";
+						ssize_t n = send(event_client_socket, message, sizeof(message), 0);
+						if (n < 0) {
+							err_exit("sending to client socket : " + std::string(strerror(errno)));
+						} else {
+							// 메시지 전송 성공 -> 해당 클라이언트에 보낼 메시지 삭제 해주기
+						}
 					}
 				}
 			}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[]) {
 				int event_client_socket = occurred_events[i].ident;
 				if (occurred_events[i].filter == EVFILT_READ) {
 					char buffer[1024];
+					memset(buffer, 0, sizeof(buffer));
 					ssize_t n = recv(event_client_socket, buffer, sizeof(buffer), 0);
 					if (n < 0) {
 						err_exit("receiving from client socket : " + std::string(strerror(errno)));
@@ -44,12 +45,15 @@ int main(int argc, char *argv[]) {
 						close(event_client_socket);
 					} else {
 						// 클라이언트 메시지 수신 성공
-						std::cout << buffer << std::endl;
+						std::cout << "[" << event_client_socket << "] client : " << buffer << std::endl;
+						// 클라이언트에 보낼 메시지 작성 후 전송
+						char *reply = buffer;
+						send(event_client_socket, reply, sizeof(buffer), 0);
 					}
 				// WRITE 이벤트 발생
 				} else if (occurred_events[i].filter == EVFILT_WRITE) {
 					// 해당 클라이언트에 보낼 메시지가 있는 경우만 전송하게 조건 추가
-					char message[] = "Message";
+					char message[] = "";
 					ssize_t n = send(event_client_socket, message, sizeof(message), 0);
 					if (n < 0) {
 						err_exit("sending to client socket : " + std::string(strerror(errno)));


### PR DESCRIPTION
## 개요
Read 이벤트만으로 핸들링하는 로직으로 구현

## 작업사항
- `write` 이벤트 핸들링은 남겨두되, `false` 조건문으로 block
- `read` 이벤트에서 `send`까지 실행하는 로직 구현
- 이전 브랜치에서 누락된 커밋 작업 : 클라이언트 소켓 생성 시 호스트네임을 갖는 클라이언트 서버에 추가하기
- 클라이언트 생성 시 임시 인사말 `send` (연결 확인)

## 변경로직
- `write` 이벤트에 대한 block은, 추후 read 이벤트에서 답장 보내는걸 실패할 경우를 대비해서 남겨두기 위함
