### PR TITLE
[Fix] command 자식 클래스 수정 #65

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -31,7 +31,7 @@ const Client Channel::findClient(Client client, std::string name) const {
 	std::vector<Message> messages;
 
 	fd.push_back(client.getFd());
-	messages.push_back(Message(fd, ERR_NOSUCHNICK, name));
+	messages.push_back(Message(fd, ERR_NOTONCHANNEL, name));
 	throw messages;
 }
 

--- a/Client.cpp
+++ b/Client.cpp
@@ -16,6 +16,8 @@ int Client::getFd() const { return _fd; }
 
 bool Client::getIsAdmin() const { return _isAdmin; }
 
+const std::set<std::string> Client::getChannels() const { return _joinedChannels; }
+
 void Client::setName(const std::string name) { _name = name; }
 
 void Client::setNickName(const std::string nickName) { _nickName = nickName; }

--- a/Client.cpp
+++ b/Client.cpp
@@ -16,7 +16,7 @@ int Client::getFd() const { return _fd; }
 
 bool Client::getIsAdmin() const { return _isAdmin; }
 
-const std::set<std::string> Client::getChannels() const { return _joinedChannels; }
+const std::set<std::string> Client::getJoinedChannels() const { return _joinedChannels; }
 
 void Client::setName(const std::string name) { _name = name; }
 

--- a/Client.hpp
+++ b/Client.hpp
@@ -21,7 +21,7 @@ class Client {
 		const std::string getName() const;
 		const std::string getNickName() const;
 		const std::string getHostName() const;
-		const std::set<std::string> getChannels() const;
+		const std::set<std::string> getJoinedChannels() const;
 		int getFd() const;
 		bool getIsAdmin() const;
 		void setName(const std::string name);

--- a/Client.hpp
+++ b/Client.hpp
@@ -21,6 +21,7 @@ class Client {
 		const std::string getName() const;
 		const std::string getNickName() const;
 		const std::string getHostName() const;
+		const std::set<std::string> getChannels() const;
 		int getFd() const;
 		bool getIsAdmin() const;
 		void setName(const std::string name);

--- a/Message.cpp
+++ b/Message.cpp
@@ -3,15 +3,14 @@
 
 Message::Message() : _code(0) {}
 
-Message::Message(std::vector<int> targets, int code, std::string content) : _targets(targets), _code(code), _content(content) {}
+Message::Message(std::vector<int> targets, unsigned int code, std::string content) : _targets(targets), _code(code), _content(content) {}
 
 Message::Message(std::vector<int> targets, std::string prefix, std::string content) : _targets(targets), _code(0), _prefix(":" + prefix), _content(content) {}
 
-Message::~Message() {
-}
+Message::~Message() {}
 
 const std::string Message::getMessage() {
 	if (_code)
-		return (":ft_irc " + std::to_string(_code) + " " + _content + " " + ft::get_code_messages(_code));
+		return (":ft_irc " + ft::toString(_code) + " " + _content + " " + ft::getCodeMessage(_code));
 	return (_prefix + " " + _content);
 }

--- a/Message.cpp
+++ b/Message.cpp
@@ -11,6 +11,6 @@ Message::~Message() {}
 
 const std::string Message::getMessage() {
 	if (_code)
-		return (":ft_irc " + ft::toString(_code) + " " + _content + " " + ft::getCodeMessage(_code));
+		return (":ft_irc " + ft::codeToString(_code) + " " + _content + " " + ft::getCodeMessage(_code));
 	return (_prefix + " " + _content);
 }

--- a/Message.hpp
+++ b/Message.hpp
@@ -1,19 +1,20 @@
 #ifndef MESSAGE_HPP
 # define MESSAGE_HPP
 
-# include <string>
-# include <vector>
+#include <iostream>
+#include <vector>
+#include "srcs/utils.hpp"
 
 class Message {
 	private:
 		std::vector<int> _targets;
-		int _code;
+		unsigned int _code;
 		std::string _prefix;
 		std::string _content;
 
 	public:
 		Message();
-		Message(std::vector<int> targets, int code, std::string content);
+		Message(std::vector<int> targets, unsigned int code, std::string content);
 		Message(std::vector<int> targets, std::string prefix, std::string content);
 		~Message();
 		const std::string getMessage();

--- a/commands/Join.cpp
+++ b/commands/Join.cpp
@@ -36,6 +36,8 @@ std::vector<Message> Join::execute(){
 	for (; it != ite; it++) {
 		try{
 			channel = Server::findChannel(_client, *it);
+			if (channel.findClient(_client, _client.getNickName()) == _client)
+				continue;
 			Server::addClientToChannel(_client, channel);
 			messages.push_back(Message(channel.getFds(), _client.getNickName(), _type + " " + *it));
 		}

--- a/commands/Kick.cpp
+++ b/commands/Kick.cpp
@@ -9,13 +9,18 @@ std::vector<Message> format
 <clientNick>!<clientName>@<clientHost> KICK <channel> <target> :<reason>
 */
 std::vector<Message> Kick::execute() {
-	Channel channel = Server::findChannel(_client, _channel);
-	checkIsAdmin(channel);
-	Client target = channel.findClient(_client, _target);
-	Server::removeClientFromChannel(target, channel);
-	std::vector<int> targetFd = channel.getFds();
 	std::vector<Message> messages;
-	messages.push_back(Message(targetFd, _client.getNickName(), getMsg()));
+	try {
+		Channel channel = Server::findChannel(_client, _channel);
+		checkIsAdmin(channel);
+		Client target = channel.findClient(_client, _target);
+		Server::removeClientFromChannel(target, channel);
+		std::vector<int> targetFd = channel.getFds();
+		messages.push_back(Message(targetFd, _client.getNickName(), getMsg()));
+	}
+	catch (std::vector<Message> &e) {
+		messages.push_back(e[0]);
+	}
 	return (messages);
 }
 

--- a/commands/Oper.cpp
+++ b/commands/Oper.cpp
@@ -10,12 +10,16 @@ std::vector<Message> format
 */
 std::vector<Message> Oper::execute()
 {
-	checkValidPassword();
-	_client.setIsAdmin(true);
-	std::vector<int> targetFd;
-	targetFd.push_back(_client.getFd());
 	std::vector<Message> messages;
-	messages.push_back(Message(targetFd, RPL_YOUREOPER, _client.getNickName()));
+	try {
+		checkValidPassword();
+		_client.setIsAdmin(true);
+		std::vector<int> targetFd;
+		targetFd.push_back(_client.getFd());
+		messages.push_back(Message(targetFd, RPL_YOUREOPER, _client.getNickName()));
+	} catch (std::vector<Message> &e) {
+		messages.push_back(e[0]);
+	}
 	return (messages);
 }
 

--- a/commands/Part.cpp
+++ b/commands/Part.cpp
@@ -21,8 +21,7 @@ std::vector<Message> Part::execute(){
 		catch (std::vector<Message> &e){
 			std::vector<int> targetFd;
 			std::vector<Message> messages;
-			targetFd.push_back(_client.getFd());
-			messages.push_back(Message(targetFd, ERR_NOSUCHCHANNEL, *it));
+			messages.push_back(e[0]);
 		}
 	}
 	return messages;

--- a/commands/PrivMsg.cpp
+++ b/commands/PrivMsg.cpp
@@ -9,7 +9,7 @@ const std::string PrivMsg::getPrefix() const
 	return (_client.getNickName() + "!" + _client.getName() + "@" + _client.getHostName());
 }
 
-const std::string PrivMsg::getMsg() const { return (_target + " :" + _msg); }
+const std::string PrivMsg::getMsg(std::string &name) const { return (name + " :" + _msg); }
 
 /*
 std::vector<Message> format
@@ -24,13 +24,21 @@ std::vector<Message> PrivMsg::execute() {
 
 	for (; it != ite; it++) {
 		if ((*it)[0] == '#') {
-			Channel target = Server::findChannel(_client, *it);
-			targetFd = target.getFds();
-			messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
+			try {
+				Channel target = Server::findChannel(_client, *it);;
+				targetFd = target.getFds();
+				messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg(*it)));
+			} catch (std::vector<Message> &e) {
+				messages.push_back(e[0]);
+			}
 		} else {
-			Client target = Server::findClient(_client, *it);
-			targetFd.push_back(target.getFd());
-			messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg()));
+			try {
+				Client target = Server::findClient(_client, *it);
+				targetFd.push_back(target.getFd());
+				messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg(*it)));
+			} catch (std::vector<Message> &e) {
+				messages.push_back(e[0]);
+			}
 		}
 	}
 	return messages;

--- a/commands/PrivMsg.hpp
+++ b/commands/PrivMsg.hpp
@@ -12,7 +12,7 @@ class PrivMsg : public Command
 		std::vector<int> findTargetClient(std::string target);
 		std::vector<int> findTargetChannel(std::string target);
 		const std::string getPrefix() const;
-		const std::string getMsg() const;
+		const std::string getMsg(std::string &name) const;
 
 	public:
 		PrivMsg(Client client, std::string target, std::string msg);

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -52,7 +52,7 @@ namespace ft
 		}
 	}
 
-	const std::string toString(unsigned int n) {
+	const std::string codeToString(unsigned int n) {
 		std::stringstream ss;
 		if (n < 10)
 			ss << "00";

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -23,7 +23,7 @@ namespace ft
         return ret;
     }
 
-	const std::string get_code_messages(int code) {
+	const std::string getCodeMessage(int code) {
 		switch (code) {
 			case RPL_WELCOME:
 				return CODE_001;
@@ -50,6 +50,16 @@ namespace ft
 			default:
 				return "";
 		}
+	}
+
+	const std::string toString(unsigned int n) {
+		std::stringstream ss;
+		if (n < 10)
+			ss << "00";
+		else if (n < 100)
+			ss << "0";
+		ss << n;
+		return ss.str();
 	}
 
 }

--- a/srcs/utils.hpp
+++ b/srcs/utils.hpp
@@ -36,7 +36,7 @@ namespace ft
 
 	std::vector<std::string> split(const std::string &str, char charset, unsigned long n = 0);
 	const std::string getCodeMessage(int code);
-	const std::string toString(unsigned int n);
+	const std::string codeToString(unsigned int n);
 
 }
 

--- a/srcs/utils.hpp
+++ b/srcs/utils.hpp
@@ -35,7 +35,8 @@ namespace ft
 {
 
 	std::vector<std::string> split(const std::string &str, char charset, unsigned long n = 0);
-	const std::string get_code_messages(int code);
+	const std::string getCodeMessage(int code);
+	const std::string toString(unsigned int n);
 
 }
 

--- a/testCommand.cpp
+++ b/testCommand.cpp
@@ -52,7 +52,7 @@ void printClients()
         std::cout << "Client name: " << it->second.getNickName() << std::endl;
         std::cout << "Client fd: " << it->second.getFd() << std::endl;
         std::cout << "Client channels: " << std::endl;
-        std::set<std::string> channels = it->second.getChannels();
+        std::set<std::string> channels = it->second.getJoinedChannels();
         std::set<std::string>::iterator it2 = channels.begin();
         std::set<std::string>::iterator ite2 = channels.end();
         for (; it2 != ite2; it2++) {
@@ -115,6 +115,11 @@ int main()
         printMessages(join.execute());
     }
     printChannels();
+    std::cout << "------------------Join again------------------" << std::endl;
+    {
+        Join join(client, "#new");
+        printMessages(join.execute());
+    }
     std::cout << "------------------PrivMsg test(to channel)------------------" << std::endl;
     {
         PrivMsg privMg(client, "#new", "hello");

--- a/testCommand.cpp
+++ b/testCommand.cpp
@@ -82,6 +82,15 @@ int main()
     } catch (std::vector<Message> &e) {
         std::cout << e[0].getMessage() << std::endl;
     }
+    std::cout << "------------------Multi Join test------------------" << std::endl;
+    try {
+        Join join7(client, "#new4,#new5,#new6,5,6,7,#new7");
+        std::vector<Message> mssag = join7.execute();
+        for (size_t i = 0; i < mssag.size(); i++)
+            std::cout << mssag[i].getMessage() << std::endl;
+    } catch (std::vector<Message> &e) {
+        std::cout << e[0].getMessage() << std::endl;
+    }
     std::cout << "------------------findChannel test------------------" << std::endl;
     try {
         Channel newChannel = Server::findChannel(client, "#new");
@@ -119,6 +128,15 @@ int main()
         PrivMsg privMg(client, client2.getNickName(), "hello");
         std::vector<Message> mssag = privMg.execute();
         std::cout << mssag[0].getMessage() << std::endl;
+    } catch (std::vector<Message> &e) {
+        std::cout << e[0].getMessage() << std::endl;
+    }
+    std::cout << "------------------Multi PrivMsg test------------------" << std::endl;
+    try {
+        PrivMsg privMg(client, client2.getNickName() + ",#new,#5,#hi", "hello");
+        std::vector<Message> mssag = privMg.execute();
+        for (size_t i = 0; i < mssag.size(); i++)
+            std::cout << mssag[i].getMessage() << std::endl;
     } catch (std::vector<Message> &e) {
         std::cout << e[0].getMessage() << std::endl;
     }

--- a/testCommand.cpp
+++ b/testCommand.cpp
@@ -13,6 +13,54 @@
 #include "commands/List.hpp"
 #include <iostream>
 
+void printChannels()
+{
+    std::cout << "------------------exist channels------------------" << std::endl;
+    std::map<std::string, Channel> channels = Server::getChannels();
+    std::map<std::string, Channel>::iterator it = channels.begin();
+    std::map<std::string, Channel>::iterator ite = channels.end();
+    for (; it != ite; it++) {
+        std::cout << "Channel name: " << it->second.getName() << std::endl;
+        std::cout << "Channel operator: " << it->second.getOperator().getNickName() << std::endl;
+        std::cout << "Channel clients: " << std::endl;
+        std::map<std::string, Client> clients = it->second.getClients();
+        std::map<std::string, Client>::iterator it2 = clients.begin();
+        std::map<std::string, Client>::iterator ite2 = clients.end();
+        for (; it2 != ite2; it2++) {
+            std::cout << "\tClient name: " << it2->second.getNickName() << std::endl;
+        }
+    }
+    std::cout << std::endl;
+}
+
+void printMessages(std::vector<Message> messages)
+{
+    std::vector<Message>::iterator it = messages.begin();
+    std::vector<Message>::iterator ite = messages.end();
+    for (; it != ite; it++) {
+        std::cout << "Message: " << it->getMessage() << std::endl;
+    }
+}
+
+void printClients()
+{
+    std::cout << "------------------exist clients------------------" << std::endl;
+    std::map<std::string, Client> clients = Server::getClients();
+    std::map<std::string, Client>::iterator it = clients.begin();
+    std::map<std::string, Client>::iterator ite = clients.end();
+    for (; it != ite; it++) {
+        std::cout << "Client name: " << it->second.getNickName() << std::endl;
+        std::cout << "Client fd: " << it->second.getFd() << std::endl;
+        std::cout << "Client channels: " << std::endl;
+        std::set<std::string> channels = it->second.getChannels();
+        std::set<std::string>::iterator it2 = channels.begin();
+        std::set<std::string>::iterator ite2 = channels.end();
+        for (; it2 != ite2; it2++) {
+            std::cout << "\tChannel name: " << *it2 << std::endl;
+        }
+    }
+}
+
 int main()
 {
 //      Server(int port, std::string password, std::string adminName, std::string adminPassword);
@@ -30,213 +78,119 @@ int main()
     Client client6(5);
     client6.setNickName("nickName6");
 
-    Channel channel("#Quit", client);
-    Server::addChannel(channel);
     Server::addClient(client);
     Server::addClient(client2);
     Server::addClient(client3);
     Server::addClient(client4);
     Server::addClient(client5);
     Server::addClient(client6);
-    Quit quit(client);
     std::cout << "------------------Join test------------------" << std::endl;
-    Join join(client, "#new");
-    Join join2(client2, "#new");
-    Join join3(client3, "#new");
-    Join join4(client4, "#new");
-    Join join5(client5, "#new2");
-    Join join6(client6, "#new2");
-    try {
-        std::vector<Message> mssag = join.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client, "#new");
+        printMessages(join.execute());
     }
-    try {
-        std::vector<Message> mssag = join2.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client2, "#new");
+        printMessages(join.execute());
     }
-    try {
-        std::vector<Message> mssag = join3.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client3, "#new");
+        printMessages(join.execute());
     }
-    try {
-        std::vector<Message> mssag = join4.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client4, "#new");
+        printMessages(join.execute());
     }
-    try {
-        std::vector<Message> mssag = join5.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client5, "#new");
+        printMessages(join.execute());
     }
-    try {
-        std::vector<Message> mssag = join6.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client6, "#new");
+        printMessages(join.execute());
     }
     std::cout << "------------------Multi Join test------------------" << std::endl;
-    try {
-        Join join7(client, "#new4,#new5,#new6,5,6,7,#new7");
-        std::vector<Message> mssag = join7.execute();
-        for (size_t i = 0; i < mssag.size(); i++)
-            std::cout << mssag[i].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Join join(client, "#new4,#new5,#new6,5,6,7,#new7");
+        printMessages(join.execute());
     }
-    std::cout << "------------------findChannel test------------------" << std::endl;
-    try {
-        Channel newChannel = Server::findChannel(client, "#new");
-        std::cout << newChannel.getName() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
-    }
-    try {
-        Channel newChannel2 = Server::findChannel(client, "#new2");
-        std::cout << newChannel2.getName() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
-    }
-    try {
-        Channel newChannel3 = Server::findChannel(client, "#new3");
-        std::cout << newChannel3.getName() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
-    }
-    std::cout << "------------------findClient test------------------" << std::endl;
-    std::map<std::string, Client> clients = Server::findChannel(client, "#new").getClients();
-    std::map<std::string, Client>::iterator it = clients.begin();
-    for (; it != clients.end(); it++)
-        std::cout << it->second.getNickName() << std::endl;
+    printChannels();
     std::cout << "------------------PrivMsg test(to channel)------------------" << std::endl;
-    try {
+    {
         PrivMsg privMg(client, "#new", "hello");
-        std::vector<Message> mssag = privMg.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(privMg.execute());
     }
     std::cout << "------------------PrivMsg test(to client)------------------" << std::endl;
-    try {
+    {
         PrivMsg privMg(client, client2.getNickName(), "hello");
-        std::vector<Message> mssag = privMg.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(privMg.execute());
     }
     std::cout << "------------------Multi PrivMsg test------------------" << std::endl;
-    try {
+    {
         PrivMsg privMg(client, client2.getNickName() + ",#new,#5,#hi", "hello");
-        std::vector<Message> mssag = privMg.execute();
-        for (size_t i = 0; i < mssag.size(); i++)
-            std::cout << mssag[i].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(privMg.execute());
     }
     std::cout << "------------------PrivMsg test(no channel)------------------" << std::endl;
-    try {
+    {
         PrivMsg privMg(client, "#new11", "hello");
-        std::vector<Message> mssag = privMg.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(privMg.execute());
     }
     std::cout << "------------------Oper success------------------" << std::endl;
-    Oper oper(client, "admin", "admin");
-    try {
-        std::vector<Message> mssag = oper.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Oper oper(client, "admin", "admin");
+        printMessages(oper.execute());
     }
     std::cout << "------------------Oper fail------------------" << std::endl;
-    Oper oper2(client2, "admin1", "admin");
-    try {
-        std::vector<Message> mssag = oper2.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Oper oper(client2, "admin1", "admin");
+        printMessages(oper.execute());
     }
     std::cout << "------------------User test------------------" << std::endl;
-    User user(client, "name");
-    try {
-        std::vector<Message> mssag = user.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        User user(client, "name");
+        printMessages(user.execute());
     }
     std::cout << "------------------Part test------------------" << std::endl;
-    try{
+    {
         Join join(client, "#Part");
         Join join2(client2, "#Part");
-        join.execute();
-        join2.execute();
+        std::cout << "------------------Join before Part------------------" << std::endl;
+        printMessages(join.execute());
+        printMessages(join2.execute());
         Part part(client, "#Part");
-        std::vector<Message> mssag = part.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    }catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(part.execute());
     }
     std::cout << "------------------Multi Part test------------------" << std::endl;
-    try{
+    {
         Join join(client, "#Part,#Part2,#Part3");
         Join join2(client2, "#Part");
-        join.execute();
-        join2.execute();
+        printMessages(join.execute());
+        printMessages(join2.execute());
         Part part(client, "#Part,#Part2,#Part3,#Part4");
-        std::vector<Message> mssag = part.execute();
-        for (unsigned int i = 0; i < mssag.size(); i++)
-            std::cout << mssag[i].getMessage() << std::endl;
-    }catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(part.execute());
     }
     std::cout << "------------------Part remainder------------------" << std::endl;
-    try{
-        Part part2(client2, "#Part");
-        std::vector<Message> mssag = part2.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    }catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+    {
+        Part part(client2, "#Part");
+        printMessages(part.execute());
     }
-    std::cout << "------------------Check Channel Remainder------------------" << std::endl;
-    try{
-        Server::findChannel(client, "#Part");
-    }catch (std::vector<Message> &e){
-        std::cout <<e[0].getMessage() << std::endl;
-    }
+    printChannels();
     std::cout << "------------------List test------------------" << std::endl;
-    try{
+    {
+        std::cout << "------------------Join before List------------------" << std::endl;
         Join join(client, "#List");
-        join.execute();
-        join = Join(client2, "#List2");
-        join.execute();
+        Join join2(client2, "#List2");
+        printMessages(join.execute());
+        printMessages(join2.execute());
         List list(client);
-        std::vector<Message> mssag = list.execute();
-        for (unsigned int i = 0; i < mssag.size(); i++)
-            std::cout << mssag[i].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(list.execute());
     }
     std::cout << "------------------Kick test------------------" << std::endl;
-    try {
+    {
         Kick kick(client, "#List", client.getNickName(), "kick");
-        std::vector<Message> mssag = kick.execute();
-        std::cout << mssag[0].getMessage() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
+        printMessages(kick.execute());
     }
-    try {
-        Channel newChannel = Server::findChannel(client, "#List");
-        std::cout << newChannel.getName() << std::endl;
-    } catch (std::vector<Message> &e) {
-        std::cout << e[0].getMessage() << std::endl;
-    }
+    printChannels();
+    printClients();
     return (0);
 }


### PR DESCRIPTION
## 개요
command 자식 클래스 수정
## 작업사항
- PRIVMSG 쉼표로 타겟 구분해서 여러 메시지 보낼 수 있도록 수정
- Channel.findClient() 메소드에서 client 못찾았을 시 ERR_NOTONCHANNEL throw 하도록 수정
- try-catch문 execute() 안에서 처리되도록 수정
- Client에 getChannels 추가
- utils에 codeToString(unsigned int) 추가
- Message의 멤버 변수 _code 자료형 변경(int -> unsigned int)
- test용 함수 추가
