### PR TITLE
[Feat] password가 다를 때 fd 삭제 로직 추가 #91

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -7,7 +7,7 @@ Client::Client(int fd, Server* server) : _fd(fd), _server(server), _isVerified(f
 	_lastPingTime = time(NULL);
 }
 
-Client::Client(const Client& client) : _fd(client._fd), _server(client._server), _isVerified(client._isVerified), _name(client._name), _nickName(client._nickName), _hostName(client._hostName), _joinedChannels(client._joinedChannels), _isAdmin(client._isAdmin) {}
+Client::Client(const Client& client) : _fd(client._fd), _server(client._server), _name(client._name), _nickName(client._nickName), _hostName(client._hostName), _joinedChannels(client._joinedChannels), _isVerified(client._isVerified), _isAdmin(client._isAdmin) {}
 
 Client::~Client() {}
 
@@ -22,6 +22,8 @@ const std::string Client::getHostName() const { return _hostName; }
 int Client::getFd() const { return _fd; }
 
 bool Client::getIsAdmin() const { return _isAdmin; }
+
+bool Client::getIsVerified() const { return _isVerified; }
 
 time_t Client::getLastPingTime() const { return _lastPingTime; }
 

--- a/Client.cpp
+++ b/Client.cpp
@@ -1,13 +1,13 @@
 #include "Client.hpp"
 
-Client::Client() :  _fd(-1), _isAdmin(false) {}
+Client::Client() :  _fd(-1), _isVerified(false), _isAdmin(false) {}
 
-Client::Client(int fd, Server* server) : _fd(fd), _server(server), _isAdmin(false) {
+Client::Client(int fd, Server* server) : _fd(fd), _server(server), _isVerified(false), _isAdmin(false) {
 	_server->addClient(this);
 	_lastPingTime = time(NULL);
 }
 
-Client::Client(const Client& client) : _fd(client._fd), _server(client._server), _name(client._name), _nickName(client._nickName), _hostName(client._hostName), _joinedChannels(client._joinedChannels), _isAdmin(client._isAdmin) {}
+Client::Client(const Client& client) : _fd(client._fd), _server(client._server), _isVerified(client._isVerified), _name(client._name), _nickName(client._nickName), _hostName(client._hostName), _joinedChannels(client._joinedChannels), _isAdmin(client._isAdmin) {}
 
 Client::~Client() {}
 
@@ -34,6 +34,8 @@ void Client::setNickName(const std::string& nickName) { _nickName = nickName; }
 void Client::setHostName(const std::string& hostName) { _hostName = hostName; }
 
 void Client::setIsAdmin(const bool isAdmin) { _isAdmin = isAdmin; }
+
+void Client::setIsVerified(const bool isVerified) { _isVerified = isVerified; }
 
 void Client::setLastPingTime(const size_t pingTime) { _lastPingTime = pingTime; }
 

--- a/Client.hpp
+++ b/Client.hpp
@@ -16,6 +16,7 @@ class Client {
 		std::string _nickName;
 		std::string _hostName;
 		std::set<std::string> _joinedChannels;
+		bool _isVerified;
 		bool _isAdmin;
 		time_t _lastPingTime;
 
@@ -38,6 +39,7 @@ class Client {
 		void setNickName(const std::string& nickName);
 		void setHostName(const std::string& hostName);
 		void setIsAdmin(const bool isAdmin);
+		void setIsVerified(const bool isVerified)
 		void setLastPingTime(const size_t pingTime);
 
 		void joinChannel(const std::string& target);

--- a/Client.hpp
+++ b/Client.hpp
@@ -33,13 +33,14 @@ class Client {
 		const std::set<std::string> getJoinedChannels() const;
 		int getFd() const;
 		bool getIsAdmin() const;
+		bool getIsVerified() const;
 		time_t getLastPingTime() const;
 
 		void setName(const std::string& name);
 		void setNickName(const std::string& nickName);
 		void setHostName(const std::string& hostName);
 		void setIsAdmin(const bool isAdmin);
-		void setIsVerified(const bool isVerified)
+		void setIsVerified(const bool isVerified);
 		void setLastPingTime(const size_t pingTime);
 
 		void joinChannel(const std::string& target);

--- a/commands/Join.cpp
+++ b/commands/Join.cpp
@@ -38,7 +38,7 @@ void Join::execute(){
 
 			_client->joinChannel(*it);
 			messages.push_back(Message(channel->getFds(), getPrefix(), _type + " " + *it));
-		} catch (Message &e) {
+		} catch (Message& e) {
 			try {
 				checkValidName(*it);
 				checkChannelNum();
@@ -48,7 +48,7 @@ void Join::execute(){
 				_client->getServer()->addChannel(channel);
 				_client->joinChannel(*it);
 				messages.push_back(Message(channel->getFds(), getPrefix(), _type + " " + *it));
-			} catch (Message &e) {
+			} catch (Message& e) {
 				messages.push_back(e);
 			}
 		}

--- a/commands/Kick.cpp
+++ b/commands/Kick.cpp
@@ -33,7 +33,7 @@ void Kick::execute() {
 
 		messages.push_back(Message(targetFd, _client->getNickName(), getMsg()));
 		target->leaveChannel(_channel);
-	} catch (Message &e) {
+	} catch (Message& e) {
 		messages.push_back(e);
 	}
 	sendMessages(messages);

--- a/commands/Nick.cpp
+++ b/commands/Nick.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "Nick.hpp"
 
 Nick::Nick(Client* client, const std::string& nick) : Command(client, "NICK"), _nick(nick) {}
@@ -25,6 +27,14 @@ void Nick::execute() {
 	std::vector<Message> messages;
 
 	if (_client->getNickName() == "") {
+		if (!_client->getIsVerified()) {
+			targetFdVector.push_back(_client->getFd());
+			messages.push_back(Message(targetFdVector, ERR_PASSWDMISMATCH, _client->getNickName()));
+			sendMessages(messages);
+			close(_client->getFd());
+			_client->leaveServer();
+			return ;
+		}
 		renameFirstNick();
 	} else if (clients.find(_nick) != clients.end()) {
 		targetFd.insert(_client->getFd());

--- a/commands/Oper.cpp
+++ b/commands/Oper.cpp
@@ -19,7 +19,7 @@ void Oper::execute() {
 
 		targetFd.push_back(_client->getFd());
 		messages.push_back(Message(targetFd, RPL_YOUREOPER, _client->getNickName()));
-	} catch (Message &e) {
+	} catch (Message& e) {
 		messages.push_back(e);
 	}
 	sendMessages(messages);

--- a/commands/Part.cpp
+++ b/commands/Part.cpp
@@ -17,7 +17,7 @@ void Part::execute() {
 			channel->findClient(_client, _client->getNickName());
 			messages.push_back(Message(channel->getFds(), getPrefix(), _type + " " + *it));
 			_client->leaveChannel(*it);
-		} catch (Message &e) {
+		} catch (Message& e) {
 			messages.push_back(e);
 		}
 	}

--- a/commands/Pass.cpp
+++ b/commands/Pass.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "Pass.hpp"
 
 Pass::Pass(Client* client, const std::string& password) : Command(client, "PASS"), _password(password) {};
@@ -5,14 +7,15 @@ Pass::Pass(Client* client, const std::string& password) : Command(client, "PASS"
 Pass::~Pass() {};
 
 void Pass::execute() {
+	if (_client->getServer()->getPassword() == _password)
+		return ;
+
+	std::vector<int> targets;
 	std::vector<Message> messages;
 
-	if (_client->getServer()->getPassword() != _password) {
-		std::vector<int> targets;
-		
-		targets.push_back(_client->getFd());
-		messages.push_back(Message(targets, ERR_PASSWDMISMATCH, _client->getNickName()));
-		sendMessages(messages);
-		_client->leaveServer();
-	}
+	targets.push_back(_client->getFd());
+	messages.push_back(Message(targets, ERR_PASSWDMISMATCH, _client->getNickName()));
+	sendMessages(messages);
+	close(_client->getFd());
+	_client->leaveServer();
 };

--- a/commands/Pass.cpp
+++ b/commands/Pass.cpp
@@ -7,8 +7,10 @@ Pass::Pass(Client* client, const std::string& password) : Command(client, "PASS"
 Pass::~Pass() {};
 
 void Pass::execute() {
-	if (_client->getServer()->getPassword() == _password)
+	if (_client->getServer()->getPassword() == _password) {
+		_client->setIsVerified(true);
 		return ;
+	}
 
 	std::vector<int> targets;
 	std::vector<Message> messages;

--- a/commands/PrivMsg.cpp
+++ b/commands/PrivMsg.cpp
@@ -31,7 +31,7 @@ void PrivMsg::execute() {
 				targetFd.push_back(target->getFd());
 				messages.push_back(Message(targetFd, getPrefix(), "PRIVMSG " + getMsg(*it)));
 			}
-		} catch (Message &e) {
+		} catch (Message& e) {
 			messages.push_back(e);
 		}
 	}


### PR DESCRIPTION
## 개요
password가 다를 때 fd 삭제 로직 추가

## 작업사항
- `/connect localhost 6667 123` 처럼 패스워드를 입력하는 경우에는 `pass->execute()`로 패스워드 확인이 가능함.
- 하지만 `/connect localhost 6667` 처럼 패스워드를 아예 입력하지 않는 경우 PASS 명령어 자체가 들어오지를 않음.
- 때문에 Client 객체에 멤버 변수 `_isVerified`를 추가하여 NICK 명령어 실행 시 유저 접근을 차단하는 로직을 추가함.
- Pass 에서 실패할 경우 해당 클라이언트의 fd를 `close()` 한 뒤 `_client->leaveServer()` 실행.

## 변경로직
- 내용을 적어주세요.
