### PR TITLE
[Feat] 클라이언트에 보내는 ping 전송부 삭제#113

### DIFF
--- a/srcs/client_socket.cpp
+++ b/srcs/client_socket.cpp
@@ -61,10 +61,10 @@ void create_client_socket(int server_socket, int kq, Server* server) {
         client->setHostName(client_host);
     }
 
-	struct kevent client_socket_event[2];
-	EV_SET(&client_socket_event[0], new_client_socket, EVFILT_READ, EV_ADD, 0, 0, NULL);
-	EV_SET(&client_socket_event[1], new_client_socket, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
-	kevent(kq, &client_socket_event[0], 2, NULL, 0, NULL);
+	struct kevent client_socket_event;
+	EV_SET(&client_socket_event, new_client_socket, EVFILT_READ, EV_ADD, 0, 0, NULL);
+	// EV_SET(&client_socket_event[1], new_client_socket, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
+	kevent(kq, &client_socket_event, 2, NULL, 0, NULL);
 
 	// 임시 접속 메시지
 	char message[] = "🍀 WELCOME TO IRC SERVER 🍀\n";


### PR DESCRIPTION
## 개요
클라이언트에 보내는 PING 전송부 삭제

## 작업사항
- PING 보내는 코드 삭제
- 클라이언트 소켓의 WRITE 이벤트 등록 삭제

## 변경로직
- 이벤트는 클라이언트/서버 소켓의 각 READ만 등록됨
- 클라이언트에게 PING 보내지 않음
