### PR TITLE
[Fix] oldnick 추가 Close -121

### DIFF
--- a/srcs/command/Nick.cpp
+++ b/srcs/command/Nick.cpp
@@ -47,8 +47,9 @@ void Nick::execute() {
 
 	Client* newClient = new Client(*_client);
 
-	newClient->setNickName(_nick);
-	newClient->getServer()->addClient(newClient);
+    std::string oldNickName = _client->getNickName();
+    newClient->setNickName(_nick);
+    newClient->getServer()->addClient(newClient);
 
 	std::set<int> pureTargetFds;
 	std::set<std::string> channels = _client->getJoinedChannels();
@@ -65,6 +66,6 @@ void Nick::execute() {
 	_client->leaveServer();
 	pureTargetFds.insert(newClient->getFd());
 	targetFds.insert(targetFds.begin(),pureTargetFds.begin(), pureTargetFds.end());
-	_messages.push_back(Message(targetFds, getPrefix(_client->getNickName()), getMsg()));
+	_messages.push_back(Message(targetFds, getPrefix(oldNickName), getMsg()));
 	sendMessages();
 }


### PR DESCRIPTION
## 개요
nick 명령어사용시 새롭게 추가되는것을 안넘겨주어서 oldnick추가

## 변경로직
_client가 leave하기 전에 oldnick 저장
