### PR TITLE
[Fix] 버퍼 사이즈를 넘어가는 경우 핸들링 #129

### DIFF
--- a/srcs/message/Message.cpp
+++ b/srcs/message/Message.cpp
@@ -25,7 +25,13 @@ void Message::sendMessage() {
 	std::string message = getMessage();
 
 	for (std::vector<int>::iterator it = _targets.begin(); it != _targets.end(); it++) {
-		send(*it, message.c_str(), message.size(), 0);
+		std::string message_copy = message;
+		while (true) {
+			ssize_t n = send(*it, message_copy.c_str(), message_copy.size(), 0);
+			if (n == (ssize_t)message_copy.size())
+				break;
+			message_copy = message_copy.substr(n);
+		}
 		// std::cout << "Sending message to client[" << *it << "]" << std::endl;
 		// std::cout << message << std::endl;
 	}

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -108,20 +108,28 @@ void Server::execute() {
 					continue ;
 			} else {
 				int clientSocket = events[i].ident;
+				std::vector<char> buffer;
 
-				char buffer[1024];
-				memset(buffer, 0, sizeof(buffer));
-				ssize_t n = recv(clientSocket, buffer, sizeof(buffer), 0);
+				while (true) {
+					char receiver[1024];
+					memset(receiver, 0, sizeof(buffer));
+					ssize_t n = recv(clientSocket, receiver, sizeof(receiver), 0);
+					if (n <= 0)
+						break;
+					for (int i = 0; receiver[i] != '\0'; ++i)
+						buffer.push_back(receiver[i]);
+				}
 
-				if (n < 0) {
-					continue ;
-				} else if (n == 0) {
+				if (buffer.empty()) {
 					// std::cout << "Client[" << clientSocket << "] closed connection" << std::endl;
 					close(clientSocket);
 				} else {
 					// std::cout << "client[" << clientSocket << "]" << std::endl;
-					// std::cout << buffer << std::endl;
-					std::vector<std::string> tokens = split(std::string(buffer), "\r\n");
+					// std::vector<char>::iterator itr = buffer.begin();
+					// while (itr != buffer.end())
+						// std::cout << *itr++;
+					// std::cout << std::endl;
+					std::vector<std::string> tokens = split(std::string(buffer.begin(), buffer.end()), "\r\n");
 					std::vector<std::string>::const_iterator it = tokens.begin();
 					std::vector<std::string>::const_iterator ite = tokens.end();
 


### PR DESCRIPTION
## 개요
버퍼 사이즈를 넘어가는 경우 핸들링

## 작업사항
- `recv()` 함수 반복 로직 변경
- `send()` 함수 반복 로직 변경

## 변경로직
- `recv()` 함수와 `send()` 함수의 리턴값에 따라 반복되도록 로직 변경
- `buffer` 자료형 `vector<char>`로 변경