### PR TITLE
[Fix] quit 중복 시 abort 에러 #134

### DIFF
--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -121,7 +121,12 @@ void Server::execute() {
 				}
 
 				if (buffer.empty()) {
-					// std::cout << "Client[" << clientSocket << "] closed connection" << std::endl;
+					std::cout << "Client[" << clientSocket << "] closed connection" << std::endl;
+					try {
+						Quit(findClient(clientSocket)).execute();
+					} catch (Message e) {
+						e.sendMessage();
+					}
 					close(clientSocket);
 				} else {
 					// std::cout << "client[" << clientSocket << "]" << std::endl;

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -125,9 +125,7 @@ void Server::execute() {
 					std::cout << "Client[" << clientSocket << "] closed connection" << std::endl;
 					try {
 						Quit(findClient(clientSocket)).execute();
-					} catch (Message e) {
-						e.sendMessage();
-					}
+					} catch (Message e) {}
 					close(clientSocket);
 				} else {
 					// std::cout << "client[" << clientSocket << "]" << std::endl;

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -1,5 +1,6 @@
 #include "Server.hpp"
 #include "ircserv.hpp"
+#include "Quit.hpp"
 
 Server::Server(int port, int kq, int serverSocket, const std::string& password, const std::string& adminName, const std::string& adminPassword): _port(port),_kq(kq), _serverSocket(serverSocket), _password(password),_adminName(adminName), _adminPassword(adminPassword) {
 	Client *bot = new Client(1, this);

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -10,7 +10,6 @@
 #include "Channel.hpp"
 #include "Message.hpp"
 #include "utils.hpp"
-#include "Quit.hpp"
 
 class Client;
 class Channel;

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -10,6 +10,7 @@
 #include "Channel.hpp"
 #include "Message.hpp"
 #include "utils.hpp"
+#include "Quit.hpp"
 
 class Client;
 class Channel;


### PR DESCRIPTION
## 개요
클라이언트 불완전 종료 시 정리 작업, 그로 인한 abort 에러 핸들링

## 작업사항
- 클라이언트 불완전 종료 시 `Quit` 객체 불러와서 정리 작업 실행
- 같은 이벤트를 뱉는 정상 종료 시 중복 abort로 인한 에러 block

## 변경로직
- `recv()` 함수의 리턴값에 의해 클라이언트 소켓을 `close()` 해줄 때, close 하기 전 `Quit` 실행
