### PR TITLE
[Fix] nickname 전체 수정 #127

### DIFF
--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -2,7 +2,7 @@
 
 Client::Client() :  _fd(-1), _isVerified(false), _isAdmin(false) {}
 
-Client::Client(int fd, Server* server) : _fd(fd), _server(server), _isVerified(false), _isAdmin(false) {
+Client::Client(int fd, Server* server) : _fd(fd), _server(server), _nickName("*"), _isVerified(false), _isAdmin(false) {
 	_server->addClient(this);
 }
 

--- a/srcs/command/Command.cpp
+++ b/srcs/command/Command.cpp
@@ -8,6 +8,20 @@ const std::string Command::getPrefix() const {
 	return _client->getNickName() + "!" + _client->getName() + "@" + _client->getHostName();
 }
 
+void Command::checkClient() {
+	if (!_client->getIsVerified()) {
+		Message msg(ERR_NOTREGISTERED);
+
+		msg.addTarget(_client->getFd());
+		msg.addParam(_client->getNickName());
+		_messages.push_back(msg);
+		sendMessages();
+		close(_client->getFd());
+		_client->leaveServer();
+		throw std::exception();
+	}
+}
+
 void Command::sendMessages() {
 	std::vector<Message>::iterator it = _messages.begin();
 	std::vector<Message>::iterator ite = _messages.end();

--- a/srcs/command/Command.hpp
+++ b/srcs/command/Command.hpp
@@ -20,6 +20,7 @@ class Command {
 		Command(Client* client, std::string type);
 		virtual ~Command();
 
+		void checkClient();
 		void sendMessages();
 		virtual void execute() = 0;
 };

--- a/srcs/command/Nick.hpp
+++ b/srcs/command/Nick.hpp
@@ -8,7 +8,6 @@ class Nick : public Command {
 		std::string _rawNick;
 		std::string _nick;
 		const std::string getPrefix(const std::string& oldNick) const;
-		void renameFirstNick();
 		void checkValidNick();
 
 	public:

--- a/srcs/command/Nick.hpp
+++ b/srcs/command/Nick.hpp
@@ -5,9 +5,11 @@
 
 class Nick : public Command {
 	private:
+		std::string _rawNick;
 		std::string _nick;
 		const std::string getPrefix(const std::string& oldNick) const;
 		void renameFirstNick();
+		void checkValidNick();
 
 	public:
 		Nick(Client* client, const std::string& nick);

--- a/srcs/message/Message.cpp
+++ b/srcs/message/Message.cpp
@@ -70,12 +70,20 @@ const std::string Message::getCodeMessage(int code) {
 			return CODE_401;
 		case ERR_NOSUCHCHANNEL:
 			return CODE_403;
+		case ERR_TOOMANYCHANNELS:
+			return CODE_405;
 		case ERR_UNKNOWNCOMMAND:
 			return CODE_421;
+		case ERR_NONICKNAMEGIVEN:
+			return CODE_431;
+		case ERR_ERRONEUSNICKNAME:
+			return CODE_432;
 		case ERR_NICKNAMEINUSE:
 			return CODE_433;
 		case ERR_NOTONCHANNEL:
 			return CODE_442;
+		case ERR_NOTREGISTERED:
+			return CODE_451;
 		case ERR_CHANOPRIVSNEEDED:
 			return CODE_482;
 		case RPL_LIST:

--- a/srcs/message/Message.hpp
+++ b/srcs/message/Message.hpp
@@ -7,30 +7,35 @@
 #include "utils.hpp"
 
 enum e_code {
-	RPL_WELCOME = 001,
-	ERR_NOSUCHNICK = 401,
-	ERR_NOSUCHCHANNEL = 403,
-	ERR_TOOMANYCHANNELS = 405,
-	ERR_UNKNOWNCOMMAND = 421,
-	ERR_NICKNAMEINUSE = 433,
-	ERR_NOTONCHANNEL = 442,
-	ERR_CHANOPRIVSNEEDED = 482,
-	RPL_LIST = 322,
-	RPL_LISTEND = 323,
-	RPL_NAMREPLY = 353,
-	RPL_NAMEND = 366,
-	RPL_YOUREOPER = 381,
-	ERR_NEEDMOREPARAMS = 461,
-	ERR_PASSWDMISMATCH = 464
+    RPL_WELCOME = 001,
+    ERR_NOSUCHNICK = 401,
+    ERR_NOSUCHCHANNEL = 403,
+    ERR_TOOMANYCHANNELS = 405,
+    ERR_UNKNOWNCOMMAND = 421,
+    ERR_NONICKNAMEGIVEN = 431,
+    ERR_ERRONEUSNICKNAME = 432,
+    ERR_NICKNAMEINUSE = 433,
+    ERR_NOTONCHANNEL = 442,
+	ERR_NOTREGISTERED = 451, 
+    ERR_CHANOPRIVSNEEDED = 482,
+    RPL_LIST = 322,
+    RPL_LISTEND = 323,
+    RPL_NAMREPLY = 353,
+    RPL_NAMEND = 366,
+    RPL_YOUREOPER = 381,
+    ERR_NEEDMOREPARAMS = 461,
+    ERR_PASSWDMISMATCH = 464,
 };
-
 # define CODE_001 ":Welcome to the ft_IRC server"
 # define CODE_401 ":No such nick"
 # define CODE_403 ":No such channel"
 # define CODE_405 ":You have joined too many channels"
 # define CODE_421 ":Unknown command"
+# define CODE_431 ":No nickname given"
+# define CODE_432 ":Erroneus nickname"
 # define CODE_433 ":Nickname is already in use"
 # define CODE_442 ":Not on that channel"
+# define CODE_451 ":You have not registered"
 # define CODE_482 ":You're not an channel operator"
 # define CODE_322 ""
 # define CODE_353 ""
@@ -49,8 +54,8 @@ class Message {
 	private:
 		std::vector<int> _targets;
 		std::string _prefix;
-		std::vector<std::string> _params;
 		std::string _command;
+		std::vector<std::string> _params;
 		std::string _trailer;
 
 		const std::string codeToString(unsigned int n);

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -136,12 +136,10 @@ void Server::execute() {
 					for (; it != ite; it++) {
 						try {
 							Command* command = parse(findClient(clientSocket), *it);
-
 							command->execute();
 							delete command;
-						} catch (Message& e) {
-							e.sendMessage();
 						} catch (std::exception& e) {
+							// delete command 처리해야 함
 							continue ;
 						}
 					}

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -136,10 +136,12 @@ void Server::execute() {
 					for (; it != ite; it++) {
 						try {
 							Command* command = parse(findClient(clientSocket), *it);
+
 							command->execute();
 							delete command;
+						} catch (Message& e) {
+							e.sendMessage();
 						} catch (std::exception& e) {
-							// delete command 처리해야 함
 							continue ;
 						}
 					}


### PR DESCRIPTION
## 개요
nick 클래스 전체 수정

## 작업사항
- client의 `_nickname` 변수의 초기값을 "*"로 수정했습니다.
- irssi 클라이언트에서 알아서 새로운 닉네임을 추천해주기 때문에 `rename()` 함수 삭제했습니다.
- 닉네임 유효성 검사 시 던지는 에러들이 추가됐습니다.
    - **ERR_NONICKNAMEGIVEN(431)** : 인자가 없거나 비어있을 때
    - **ERR_ERRONEUSNICKNAME(432)** : 유효하지 않은 닉네임일 때(알파벳, 숫자, _ 이외의 문자)
    - **ERR_NOTREGISTERED(451)** : 유효한 유저가 아닐 때

## 변경로직
- 
