### PR TITLE
[Fix] recv() 함수 로직 수정 및 여러 수정사항 close #140

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = ircserv
 CXX = c++
-CXXFLAGS = -g -Wall -Wextra -Werror -std=c++98 -Isrcs -Isrcs/command -Isrcs/channel -Isrcs/message -Isrcs/client -Isrcs/server #-fsanitize=address
+CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -Isrcs -Isrcs/command -Isrcs/channel -Isrcs/message -Isrcs/client -Isrcs/server #-g #-fsanitize=address
 
 SRCDIR=srcs
 CMDDIR=srcs/command

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -26,11 +26,11 @@ bool Client::getIsVerified() const { return _isVerified; }
 
 const std::set<std::string> Client::getJoinedChannels() const { return _joinedChannels; }
 
-std::string Client::getBuffer() const { return buffer; }
+std::string Client::getBuffer() const { return _buffer; }
 
-void Client::clearBuffer() { buffer.clear(); }
+void Client::clearBuffer() { _buffer.clear(); }
 
-void Client::addToBuffer(const std::string& str) { buffer += str; }
+void Client::addToBuffer(const std::string& str) { _buffer.append(str); }
 
 void Client::setName(const std::string& name) { _name = name; }
 

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -26,6 +26,12 @@ bool Client::getIsVerified() const { return _isVerified; }
 
 const std::set<std::string> Client::getJoinedChannels() const { return _joinedChannels; }
 
+std::string Client::getBuffer() const { return buffer; }
+
+void Client::clearBuffer() { buffer.clear(); }
+
+void Client::addToBuffer(const std::string& str) { buffer += str; }
+
 void Client::setName(const std::string& name) { _name = name; }
 
 void Client::setNickName(const std::string& nickName) { _nickName = nickName; }

--- a/srcs/client/Client.hpp
+++ b/srcs/client/Client.hpp
@@ -18,7 +18,7 @@ class Client {
 		std::set<std::string> _joinedChannels;
 		bool _isVerified;
 		bool _isAdmin;
-		std::string buffer;
+		std::string _buffer;
 
 	public:
 		Client();

--- a/srcs/client/Client.hpp
+++ b/srcs/client/Client.hpp
@@ -18,6 +18,7 @@ class Client {
 		std::set<std::string> _joinedChannels;
 		bool _isVerified;
 		bool _isAdmin;
+		std::string buffer;
 
 	public:
 		Client();
@@ -33,6 +34,10 @@ class Client {
 		int getFd() const;
 		bool getIsAdmin() const;
 		bool getIsVerified() const;
+
+		std::string getBuffer() const;
+		void clearBuffer();
+		void addToBuffer(const std::string& str);
 
 		void setName(const std::string& name);
 		void setNickName(const std::string& nickName);

--- a/srcs/command/Command.cpp
+++ b/srcs/command/Command.cpp
@@ -1,6 +1,8 @@
 #include "Command.hpp"
 
-Command::Command(Client* client, std::string type): _client(client), _type(type), _messages(std::vector<Message>()) {}
+Command::Command(Client* client, std::string type): _client(client), _type(type), _messages(std::vector<Message>()) {
+	_client->clearBuffer();
+}
 
 Command::~Command() {}
 

--- a/srcs/command/Quit.cpp
+++ b/srcs/command/Quit.cpp
@@ -25,4 +25,5 @@ void Quit::execute() {
 	}
 	_client->leaveServer();
 	sendMessages();
+	close(_client->getFd());
 }

--- a/srcs/parse.cpp
+++ b/srcs/parse.cpp
@@ -55,6 +55,7 @@ Command* parse(Client* client, const std::string& str) {
 			}
 		}
 	}
+	client->clearBuffer();
 	Message msg(ERR_UNKNOWNCOMMAND);
 	msg.addParam(command);
 	msg.addTarget(client->getFd());

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -150,6 +150,7 @@ void Server::execute() {
 							e.sendMessage();
 							delete command;
 						} catch (std::exception& e) {
+							_clients->clearBuffer();
 							if (command)
 								delete command;
 							continue ;

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -150,7 +150,7 @@ void Server::execute() {
 							e.sendMessage();
 							delete command;
 						} catch (std::exception& e) {
-							_clients->clearBuffer();
+							client->clearBuffer();
 							if (command)
 								delete command;
 							continue ;


### PR DESCRIPTION
## 개요
recv() 함수 로직 수정 및 여러 수정사항
## 작업사항
- Server에서 관리하던 buffer를 client마다 가지고 있도록 수정
    - 왜 와이? ^D 들어올 시 계속해서 recv() 대기하고 있어서 ^D 입력시 다른 클라이언트 입력을 blocking 해버리는 문제가 있었음
    - client마다 버퍼 가지고 있음에 따라 getBuffer(), addToBuffer(), clearBuffer() 함수 추가
    - 명령어 생성시마다 버퍼 초기화 하도록 처리.
- receiver[1024] -> receiver[1025]로 변경
    - 1024로 설정했을 시 1024보다 많은 글자가 들어오면 '\0'이 안붙어서 오류가 나는 부분이 있었음. 따라서 버퍼 크기를 1025로 잡고 1024글자까지만 읽도록 수정
- socket close 하는 조건문 변경
    - buffer에 문자열을 추가하면서 확인하다 보니 client에서 아예 eof가 들어와도 연결 끊긴걸 감지 못하는 경우 발생.
    - kevent 구조체의 flags에 EV_EOF 플래그가 들어올 경우 client가 끊어진 것으로 판단, 연결 끊어주는 방식으로 변경
- '\n', '\r' 검사하는 부분을 클라이언트별로 해야 하기 때문에 위치 옮김.

- Quit 명령어 실행 시 소켓 닫아주는 부분 추가 (nc로 처리시 quit 이후에도 명령어 입력이 가능함..)
